### PR TITLE
Implement `SkipDir` in powerwalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,12 @@ powerwalk.WalkLimit(root string, walkFn filepath.WalkFunc, limit int) error
 
 The `WalkLimit` function does the same as `Walk`, except allows you to specify the number of files to concurrently walk using the `limit` argument.  The `limit` argument must be one or higher (i.e. `>0`).  Specificying a limit that's too high, causes unnecessary overhead so sensible numbers are encouraged but not enforced.
 
+### Omitting directories
+
+In order to skip some nested directories, please call `SkipDir` function with paths to directories to be omitted:
+
+```
+powerwalk.SkipDir(dir...string)
+```
+
 See the [godoc documentation](http://godoc.org/github.com/stretchr/powerwalk) for more information.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The `WalkLimit` function does the same as `Walk`, except allows you to specify t
 In order to skip some nested directories, please call `SkipDir` function with paths to directories to be omitted:
 
 ```
-powerwalk.SkipDir(dir...string)
+powerwalk.SkipDir(dir ...string)
 ```
 
 See the [godoc documentation](http://godoc.org/github.com/stretchr/powerwalk) for more information.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Go package for walking files and concurrently calling user code to handle each file.  This package walks the file system in the same way `filepath.Walk` does, except instead of calling the `walkFn` inline, it uses goroutines to allow the files to be handled concurrently.
 
-Powerwalk functions by walking concurrently over many files. In order to realize any benefits from this approach, you must tell the runtime to use multiple CPUs. For example:
+Powerwalk functions by walking concurrently over many files. When using Go in version lower than 1.5, in order to realize any benefits from this approach, you must tell the runtime to use multiple CPUs. For example:
 
 ```
 runtime.GOMAXPROCS(runtime.NumCPU())
 ```
+
+In Go 1.5 and above it isn't needed, as it's set by default.
 
 ## Usage
 
@@ -25,4 +27,3 @@ powerwalk.WalkLimit(root string, walkFn filepath.WalkFunc, limit int) error
 The `WalkLimit` function does the same as `Walk`, except allows you to specify the number of files to concurrently walk using the `limit` argument.  The `limit` argument must be one or higher (i.e. `>0`).  Specificying a limit that's too high, causes unnecessary overhead so sensible numbers are encouraged but not enforced.
 
 See the [godoc documentation](http://godoc.org/github.com/stretchr/powerwalk) for more information.
-

--- a/walker.go
+++ b/walker.go
@@ -101,7 +101,7 @@ func WalkLimit(root string, walkFn filepath.WalkFunc, limit int) error {
 				return errors.New("kill received while walking")
 			default:
 				for _, d := range dirsToSkip {
-					if strings.Contains(p, d) {
+					if strings.HasPrefix(p, d) {
 						return nil
 					}
 				}

--- a/walker.go
+++ b/walker.go
@@ -15,6 +15,7 @@ const DefaultConcurrentWalks int = 100
 
 var dirsToSkip []string
 
+// SkipDir takes variable number of arguments, which are paths not to be walked
 func SkipDir(dirs ...string) {
 	dirsToSkip = dirs
 }

--- a/walker_test.go
+++ b/walker_test.go
@@ -285,7 +285,7 @@ func TestSkipDir(t *testing.T) {
 	// max concurrency out
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	dirToSkip := fmt.Sprintf("%s/dirToSkip", testFiles)
+	dirToSkip := "test_files/dirToSkip"
 
 	// this time, let's make test dirs + one additional directory to skip
 	makeTestFiles(5, 10)
@@ -298,7 +298,7 @@ func TestSkipDir(t *testing.T) {
 	defer deleteTestFiles()
 
 	// declare directories to skip
-	//SkipDir(fmt.Sprintf("%s/dirToSkip", testFiles))
+	SkipDir(dirToSkip)
 
 	var seenLock sync.Mutex
 	seen := make(map[string]bool)
@@ -316,6 +316,4 @@ func TestSkipDir(t *testing.T) {
 
 	// check if file inside "dirToSkip" was omitted
 	assert.False(t, seen["browserHistory.txt"])
-
-	//log.Println(seen)
 }

--- a/walker_test.go
+++ b/walker_test.go
@@ -314,7 +314,7 @@ func TestSkipDir(t *testing.T) {
 
 	assert.NoError(t, Walk(testFiles, walkFunc))
 
-	// check if file inside "dirToSkip" was ommited
+	// check if file inside "dirToSkip" was omitted
 	assert.False(t, seen["browserHistory.txt"])
 
 	//log.Println(seen)


### PR DESCRIPTION
Simple implementation of `SkipDir` function.

Addresses #1 
